### PR TITLE
Charm adaptor implemented

### DIFF
--- a/include/strategies/input/adaptorInterface.h
+++ b/include/strategies/input/adaptorInterface.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <system/traits.h>
+
+/**
+ * This class serves as a interface for the adaptor for the input structures, since the input may be brought in by a RTS with it's own semantics.
+ * @type DataTypes This type is used to contain the type definitions of Load and Id which are needed inside load balancer strategies. The default typename is the global traits structure.
+ */
+template<typename DataTypes = Traits<void> >
+class AdaptorInterface {
+public:
+
+	/**
+	 * @type Load The datatype of the load contained in tasks and PEs.
+	 */
+	using Load = typename DataTypes::Load;
+  
+  /**
+   * @type Id The datatype of the id used to identify PEs and Tasks.
+   */
+  using Id = typename DataTypes::Id;
+
+  /**
+   * @type UInt The unsigned type used in the library.
+   */
+  using UInt = typename Traits<void>::UInt;
+
+	/**
+	 * @param index The index of the PE.
+	 * @return The load of the index-th PE present in this input.
+	 */
+	virtual const Load PEload(const UInt &index) = 0;
+
+	/**
+	 * @param index The index of the PE.
+	 * @return The id of the PE.
+	 */
+	virtual const Id PEId(const UInt &index) = 0;
+
+	/**
+	 * @return The ammount of PEs in the library's input.
+	 */
+	virtual const UInt PECount() = 0;
+
+	/**
+	 * @param index The index of the task.
+	 * @return The load of the index-th task present in this input.
+	 */
+	virtual const Load taskLoad(const UInt &index) = 0;
+
+	/**
+	 * @param index The index of the task.
+	 * @return The id of the task.
+	 */
+	virtual const Id taskId(const UInt &index) = 0;
+	
+	/**
+	 * @return The ammount of tasks in the library's input.
+	 */
+	virtual const UInt taskCount() = 0;
+};

--- a/include/strategies/input/charm/charmAdaptor.h
+++ b/include/strategies/input/charm/charmAdaptor.h
@@ -1,0 +1,114 @@
+#pragma once
+
+#ifdef RTS_IS_CHARM
+
+#include <vector>
+
+#include "../adaptorInterface.h"
+#include "charmTypes.h"
+#include <cassert>
+
+// Charm++ specific includes.
+#include <ckgraph.h>
+#include <CentralLB.h>
+
+/**
+ * This class is the implementation of the AdaptorInterface to be linked in the Charm environment.
+ * @details This class presents basic translation from Charm++ datatypes to generic input for load balancing strategies.
+ */
+class CharmAdaptor : AdaptorInterface<CharmTypes> {
+public:
+
+  using LDStats = BaseLB::LDStats;
+
+  /**
+   * @type PEVector a definition of a vector of Charm's ProcInfo.
+   */
+  using PEVector = std::vector<ProcInfo>;
+
+  /**
+   * @type TaskVector a definition of a vector of Charm's Vertex.
+   */
+  using TaskVector = std::vector<Vertex>;
+
+private:
+
+  /**
+   * @variable input A reference the Charm's LDStats instance.
+   */
+  LDStats *input;
+
+  /**
+   * @variable _PEVector The vector of every available PE in the environment.
+   */
+  PEVector _PEVector;
+
+  /**
+   * @variable _taskVector The vector of every migrateable task in the environment.
+   */
+  TaskVector _taskVector;
+
+  /**
+   * Populates the internal vectors that will be used to implement the interface methods.
+   */
+  void populateVectors();
+
+public:
+
+  /**
+   * The constructor funcion of this class. It is used to initialize it's internal state.
+   * @param stats The collected usefull data for load balancing, given by the Charm++ run time system.
+   */
+  CharmAdaptor(LDStats *stats) : input(stats) {
+    populateVectors();
+  }
+
+  /**
+   * @param index The index of the PE.
+   * @return The load of the index-th PE present in this input.
+   */
+  inline const Load PEload(const UInt &index) {
+    return _PEVector[index].getTotalLoad();
+  }
+
+  /**
+   * @param index The index of the PE.
+   * @return The id of the PE.
+  */
+  inline const Id PEId(const UInt &index) {
+   return _PEVector[index].getProcId();
+  }
+
+  /**
+   * @return The ammount of PEs in the library's input.
+   */
+  inline const UInt PECount() {
+    return _PEVector.size();
+  }
+
+  /**
+   * @param index The index of the task.
+   * @return The load of the index-th task present in this input.
+   */
+  inline const Load taskLoad(const UInt &index) {
+    return _taskVector[index].getVertexLoad();
+  }
+
+  /**
+   * @param index The index of the task.
+   * @return The id of the task.
+   */
+  inline const Id taskId(const UInt &index) {
+    return _taskVector[index].getVertexId();
+  }
+  
+  /**
+   * @return The ammount of tasks in the library's input.
+   */
+  inline const UInt taskCount() {
+    return _taskVector.size();
+  }
+
+};
+
+#endif

--- a/include/strategies/input/charm/charmTypes.h
+++ b/include/strategies/input/charm/charmTypes.h
@@ -1,0 +1,9 @@
+#pragma once
+
+/**
+ * This structure defines the data types used in Charm++ needed in adaptors.
+ */
+struct CharmTypes {
+  using Load = double; 
+  using Id = int;
+};

--- a/include/system/definitions.h
+++ b/include/system/definitions.h
@@ -1,0 +1,20 @@
+#pragma once 
+
+#include <system/static.h>
+
+namespace Definitions {
+
+constexpr auto charmRTS = "Charm";
+constexpr auto noRTS = "None";
+
+}
+
+#ifndef RTS
+#define RTS Definitions::noRTS
+#endif
+
+#if static_functions::const_string_equal(RTS, Definitions::charmRTS)
+#define RTS_IS_CHARM
+#elif static_functions::const_string_equal(RTS, Definitions::noRTS)
+#define RTS_IS_NONE
+#endif

--- a/include/system/static.h
+++ b/include/system/static.h
@@ -13,3 +13,15 @@ class TemplateName \
 public: \
     enum { value = std::is_same<decltype(test<T>(0)), Positive>::value }; \
 };
+
+namespace static_functions {
+
+constexpr bool const_string_equal( char const* lhs, char const* rhs )
+{
+    while (*lhs || *rhs)
+        if (*lhs++ != *rhs++)
+            return false;
+    return true;
+}
+
+}

--- a/include/system/traits.h
+++ b/include/system/traits.h
@@ -14,14 +14,19 @@ template<typename T>
 struct Traits {
   
   /**
+   * The type definition that will serve as an unsigned int inside the library.
+   */
+  typedef uint_fast32_t UInt;
+  
+  /**
    * The type definition that will serve to identify tasks and PEs of the system inside the framework.
    */
-  typedef uint_fast32_t Id;
+  typedef UInt Id;
 
   /**
    * The type definition that will serve to quantify a task's load value for the framework.
    */
-  typedef uint_fast32_t Load;
+  typedef UInt Load;
 
   /**
    * Reference to the zero value of the Load type.
@@ -103,16 +108,11 @@ struct GreedyStrategyAlgorithmTraits : Traits<void> {
 
 
 struct EagerMapTraits : Traits<void>{
-  
-  /**
-   * A definition for the unsigned int used to count elements and serve as indices.
-   */
-  typedef uint_fast32_t UInt;
 
   /**
    * The data type that represents the communication value of the EagerMap's communication matrix.
    */
-  typedef uint_fast32_t CommValue;
+  typedef UInt CommValue;
 
   /**
    * The data type that represents the communication matrix that is used by the EagerMap strategy.

--- a/src/strategies/input/charm/charmAdaptor.cpp
+++ b/src/strategies/input/charm/charmAdaptor.cpp
@@ -1,0 +1,45 @@
+#include <strategies/input/charm/charmAdaptor.h>
+
+#ifdef RTS_IS_CHARM
+
+void CharmAdaptor::populateVectors(){
+  int nPEs = input->nprocs();
+  int nTasks = input->n_objs;
+
+  int *map = new int[nPEs];
+
+  // Add the available processors into the vector of processors in the input.
+  for(auto pe = 0; pe < nPEs; ++pe) {
+    map[pe] = -1;
+    if(input->procs[pe].available) {
+      map[pe] = _PEVector.size();
+      _PEVector.push_back(ProcInfo(pe, input->procs[pe].bg_walltime, 0.0, input->procs[pe].pe_speed, true)); // Add the PE to the vector of PEs.
+    }
+  }
+
+  // Add the migrateable tasks to the vector of tasks and add the load of the non migrateable tasks to the adequate processor.
+  for(auto task = 0; task < nTasks; ++task) {
+    LDObjData &taskData = input->objData[task];
+    auto pe = input->from_proc[task]; // Get the PE's id where the task is allocated.
+    
+    if(taskData.migratable) {
+      const Load load = taskData.wallTime * input->procs[pe].pe_speed; // Calculate the load of a Task.
+      _taskVector.push_back(Vertex(task, load, true, input->from_proc[task])); // Add the task to a vector of tasks.
+
+    } else {
+      pe = map[pe];
+
+      assert(pe != -1); // Nonmigrateable task on an unavailable processor.
+
+      _PEVector[pe].totalLoad() += taskData.wallTime;
+    }
+  }
+
+  delete [] map;
+
+  // Adds the overhead to the total load of a PE.
+  for (auto pe = 0; pe < _PEVector.size(); pe++)
+    _PEVector[pe].totalLoad() +=  _PEVector[pe].overhead();
+}
+
+#endif


### PR DESCRIPTION
It is already properly placed inside the library and guarded against builds that wont be linked to charm. A makefile rule to properly build it and create its object file is yet needed to properly make the connections with the Charm environment.